### PR TITLE
added note about browser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ it('eventually works', function () {
 })
 ```
 
+## Browser support
+
+This extension only works in Node.js environment and can not be used when [running Mocha in a browser](https://mochajs.org#running-mocha-in-the-browser).
+
 <br>
 
 ## Thanks


### PR DESCRIPTION
It cannot work in browser because the way in which it finds uncaughtException handlers. Browser support would require a major rewrite, therefore this note.
