### PR TITLE
fixed usage without passing the next parameter and added README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,39 @@ If a test fails and `timeout` has not elapsed yet, it will wait `interval` milli
 
 Returns a promise, which Mocha will happily consume.
 
+## Examples
+
 ```js
 var eventually = require('mocha-eventually')
 
 it('eventually works', function () {
-  return eventually(function (next) {
+  return eventually(function () {
     assert(Math.random() > 0.9)
-    next()
+  }, 2000)
+})
+```
+
+```js
+var eventually = require('mocha-eventually')
+var myAsyncAction // function that accepts callback
+
+it('eventually works for asynchronous action', function () {
+  return eventually(function (next) {
+    myAsyncAction(function(err, result) {
+      assert(err === null)
+      next()
+    })
+  }, 2000)
+})
+```
+
+```js
+var eventually = require('mocha-eventually')
+var myPromised // function that returns promise
+
+it('eventually works for asynchronous action', function () {
+  return eventually(function () {
+    return myAsyncAction("someparam")
   }, 2000)
 })
 ```

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function eventually (fn, timeout, interval) {
       if (fn.length === 0) {
         try {
           var result = fn()
-          if (result.then) {
+          if (result && result.then) {
             result.then(function () {
               next()
             }, function (err) {

--- a/test/basic_test.js
+++ b/test/basic_test.js
@@ -46,6 +46,14 @@ describe('eventually()', function () {
       })
     }, 1000, 0)
   })
+
+  it('works when next is not passed', function () {
+    return eventually(function () { // no next parameter here
+      setTimeout(function () {
+        expect(++n).toEqual(5)
+      })
+    }, 1000, 0)
+  })
 })
 
 describe('promises', function () {


### PR DESCRIPTION
relates to https://github.com/rstacruz/mocha-eventually/issues/1

Turns out it was actually an easy fix. The code attempted to read `result.then`, which threw an exception ("cannot read property type of undefined") which was then assumed to be coming from a failed assertion and swallowed.

I also took the liberty to include examples of all available usages.
